### PR TITLE
Corrected compiler error

### DIFF
--- a/kkconsui/src/conscommon.cc
+++ b/kkconsui/src/conscommon.cc
@@ -63,7 +63,7 @@ void kinterface() {
     use_default_colors();
     atexit(kendinterface);
 //      nodelay(stdscr, TRUE);
-    ESCDELAY = 0;
+    set_escdelay(0);
     signal(SIGWINCH, &kreinit);
     kt_resize_event = 0;
 }


### PR DESCRIPTION
```
kkconsui/src/conscommon.cc:66:14: error: lvalue required as left operand of assignment
     ESCDELAY=0;
              ^
```